### PR TITLE
feat: Read audio from multiple mics

### DIFF
--- a/passive_sound_localization/read_mic.py
+++ b/passive_sound_localization/read_mic.py
@@ -1,0 +1,54 @@
+import pyaudio
+import wave
+import sys
+
+def record_audio(filename, duration, sample_rate=44100, channels=1, chunk=1024):
+    # Initialize PyAudio
+    p = pyaudio.PyAudio()
+
+    # Open stream
+    stream = p.open(format=pyaudio.paInt16,
+                    channels=channels,
+                    rate=sample_rate,
+                    input=True,
+                    frames_per_buffer=chunk)
+
+    print("* Recording audio...")
+
+    frames = []
+
+    # Calculate the number of chunks to record
+    chunks_to_record = int(sample_rate / chunk * duration)
+
+    # Record audio
+    for _ in range(chunks_to_record):
+        data = stream.read(chunk)
+        frames.append(data)
+
+    print("* Done recording")
+
+    # Stop and close the stream
+    stream.stop_stream()
+    stream.close()
+
+    # Terminate PyAudio
+    p.terminate()
+
+    # Save as WAV file
+    wf = wave.open(filename, 'wb')
+    wf.setnchannels(channels)
+    wf.setsampwidth(p.get_sample_size(pyaudio.paInt16))
+    wf.setframerate(sample_rate)
+    wf.writeframes(b''.join(frames))
+    wf.close()
+
+    print(f"* Audio saved as {filename}")
+
+if __name__ == "__main__":
+    output_filename = "output.wav"
+    record_duration = 5  # Duration in seconds
+
+    if len(sys.argv) > 1:
+        record_duration = int(sys.argv[1])
+
+    record_audio(output_filename, record_duration)

--- a/passive_sound_localization/read_mic.py
+++ b/passive_sound_localization/read_mic.py
@@ -1,19 +1,34 @@
 import pyaudio
 import wave
+import numpy as np
 import sys
 
-def record_audio(filename, duration, sample_rate=44100, channels=1, chunk=1024):
+def record_audio(filename_prefix, duration, sample_rate=44100, channels=2, chunk=1024):
     # Initialize PyAudio
     p = pyaudio.PyAudio()
+
+    # Find the device index for a 2-channel input device
+    device_index = None
+    for i in range(p.get_device_count()):
+        dev_info = p.get_device_info_by_index(i)
+        if dev_info['maxInputChannels'] >= channels:
+            device_index = i
+            break
+
+    if device_index is None:
+        print("Error: Could not find a 2-channel input device.")
+        p.terminate()
+        return
 
     # Open stream
     stream = p.open(format=pyaudio.paInt16,
                     channels=channels,
                     rate=sample_rate,
                     input=True,
+                    input_device_index=device_index,
                     frames_per_buffer=chunk)
 
-    print("* Recording audio...")
+    print(f"* Recording {channels} channels of audio...")
 
     frames = []
 
@@ -34,21 +49,27 @@ def record_audio(filename, duration, sample_rate=44100, channels=1, chunk=1024):
     # Terminate PyAudio
     p.terminate()
 
-    # Save as WAV file
-    wf = wave.open(filename, 'wb')
-    wf.setnchannels(channels)
-    wf.setsampwidth(p.get_sample_size(pyaudio.paInt16))
-    wf.setframerate(sample_rate)
-    wf.writeframes(b''.join(frames))
-    wf.close()
+    # Convert the byte string to a NumPy array
+    audio_data = np.frombuffer(b''.join(frames), dtype=np.int16)
 
-    print(f"* Audio saved as {filename}")
+    # Reshape the data to separate channels
+    audio_channels = audio_data.reshape(-1, channels)
+
+    # Save each channel to a separate WAV file
+    for i in range(channels):
+        filename = f"audio_files/{filename_prefix}_channel_{i+1}.wav"
+        with wave.open(filename, 'wb') as wf:
+            wf.setnchannels(1)  # Mono file for each channel
+            wf.setsampwidth(2)  # 2 bytes for int16
+            wf.setframerate(sample_rate)
+            wf.writeframes(audio_channels[:, i].tobytes())
+        print(f"* Audio for channel {i+1} saved as {filename}")
 
 if __name__ == "__main__":
-    output_filename = "output.wav"
+    output_filename_prefix = "output"
     record_duration = 5  # Duration in seconds
 
     if len(sys.argv) > 1:
         record_duration = int(sys.argv[1])
 
-    record_audio(output_filename, record_duration)
+    record_audio(output_filename_prefix, record_duration)

--- a/poetry.lock
+++ b/poetry.lock
@@ -607,6 +607,29 @@ typing = ["typing-extensions"]
 xmp = ["defusedxml"]
 
 [[package]]
+name = "pyaudio"
+version = "0.2.14"
+description = "Cross-platform audio I/O with PortAudio"
+optional = false
+python-versions = "*"
+files = [
+    {file = "PyAudio-0.2.14-cp310-cp310-win32.whl", hash = "sha256:126065b5e82a1c03ba16e7c0404d8f54e17368836e7d2d92427358ad44fefe61"},
+    {file = "PyAudio-0.2.14-cp310-cp310-win_amd64.whl", hash = "sha256:2a166fc88d435a2779810dd2678354adc33499e9d4d7f937f28b20cc55893e83"},
+    {file = "PyAudio-0.2.14-cp311-cp311-win32.whl", hash = "sha256:506b32a595f8693811682ab4b127602d404df7dfc453b499c91a80d0f7bad289"},
+    {file = "PyAudio-0.2.14-cp311-cp311-win_amd64.whl", hash = "sha256:bbeb01d36a2f472ae5ee5e1451cacc42112986abe622f735bb870a5db77cf903"},
+    {file = "PyAudio-0.2.14-cp312-cp312-win32.whl", hash = "sha256:5fce4bcdd2e0e8c063d835dbe2860dac46437506af509353c7f8114d4bacbd5b"},
+    {file = "PyAudio-0.2.14-cp312-cp312-win_amd64.whl", hash = "sha256:12f2f1ba04e06ff95d80700a78967897a489c05e093e3bffa05a84ed9c0a7fa3"},
+    {file = "PyAudio-0.2.14-cp38-cp38-win32.whl", hash = "sha256:858caf35b05c26d8fc62f1efa2e8f53d5fa1a01164842bd622f70ddc41f55000"},
+    {file = "PyAudio-0.2.14-cp38-cp38-win_amd64.whl", hash = "sha256:2dac0d6d675fe7e181ba88f2de88d321059b69abd52e3f4934a8878e03a7a074"},
+    {file = "PyAudio-0.2.14-cp39-cp39-win32.whl", hash = "sha256:f745109634a7c19fa4d6b8b7d6967c3123d988c9ade0cd35d4295ee1acdb53e9"},
+    {file = "PyAudio-0.2.14-cp39-cp39-win_amd64.whl", hash = "sha256:009f357ee5aa6bc8eb19d69921cd30e98c42cddd34210615d592a71d09c4bd57"},
+    {file = "PyAudio-0.2.14.tar.gz", hash = "sha256:78dfff3879b4994d1f4fc6485646a57755c6ee3c19647a491f790a0895bd2f87"},
+]
+
+[package.extras]
+test = ["numpy"]
+
+[[package]]
 name = "pybind11"
 version = "2.13.6"
 description = "Seamless operability between C++11 and Python"
@@ -792,7 +815,18 @@ files = [
     {file = "threadpoolctl-3.5.0.tar.gz", hash = "sha256:082433502dd922bf738de0d8bcc4fdcbf0979ff44c42bd40f5af8a282f6fa107"},
 ]
 
+[[package]]
+name = "wave"
+version = "0.0.2"
+description = "Whole Architecture Verification"
+optional = false
+python-versions = "*"
+files = [
+    {file = "Wave-0.0.2.tar.gz", hash = "sha256:5a895bb85e04e38c82dba90d66a5ae8f488b50c58f3fc4df868a5bcdcabb8632"},
+    {file = "Wave-0.0.2.zip", hash = "sha256:5187f49497287d218cc83d4cd1e5299dc31485ab3ed32abbaa9e95d8f73c4095"},
+]
+
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.12"
-content-hash = "25412738c8ef6cc06b426d6916f6b46510f9758f2321d6b5c2b85f968709d5ea"
+content-hash = "5e1ed56332cbb770d90b88220457977a53c5b5c9a98853334ae3ced7512721c3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,8 @@ scipy = "^1.14.1"
 scikit-learn = "^1.5.2"
 matplotlib = "^3.9.2"
 pyroomacoustics = "^0.7.7"
+pyaudio = "^0.2.14"
+wave = "^0.0.2"
 
 
 [build-system]


### PR DESCRIPTION
With this pull request, you can read audio from **multiple microphones**. I set the **default to 2 microphones** at the moment, but it is extensible for 4 microphones. 

In addition, I made the choice to save the audio from each microphone into their own separate `.wav` file. I think this would make it easier to process down the line instead of having to try and separate the audio channel from a single source.