### PR TITLE
feat: Added timeout when receiving a text response from OpenAI websocket

### DIFF
--- a/packages/passive_sound_localization/passive_sound_localization/realtime_openai_websocket.py
+++ b/packages/passive_sound_localization/passive_sound_localization/realtime_openai_websocket.py
@@ -14,15 +14,6 @@ class InvalidWebsocketURIError(Exception):
     def __init__(self, websocket_url: str) -> None:
         super().__init__(f"Invalid Websocker URI was passed: {websocket_url}")
 
-class WebsocketTCPError(Exception):
-    pass
-
-class InvalidWebsocketHandshakeError(Exception):
-    pass
-
-class WebsocketTimeOutError(Exception):
-    pass
-
 class SessionNotCreatedError(Exception):
     def __init__(self) -> None:
         super().__init__("Session was not created")

--- a/packages/passive_sound_localization/passive_sound_localization/realtime_openai_websocket.py
+++ b/packages/passive_sound_localization/passive_sound_localization/realtime_openai_websocket.py
@@ -1,4 +1,4 @@
-from websockets import Data, ConnectionClosed, InvalidHandshake, InvalidURI, WebSocketClientProtocol
+from websockets import WebSocketClientProtocol
 from websockets.sync.client import connect
 import json
 import base64
@@ -24,18 +24,24 @@ class WebsocketTimeOutError(Exception):
     pass
 
 class SessionNotCreatedError(Exception):
-    pass
+    def __init__(self) -> None:
+        super().__init__("Session was not created")
 
 class SessionNotUpdatedError(Exception):
-    pass
+    def __init__(self) -> None:
+        super().__init__("Session was not updated")
 
 class OpenAIWebsocketError(Exception):
     def __init__(self, error_code: str, error_message: str) -> None:
         super().__init__(f"OpenAI websocket erred with error type `{error_code}`: {error_message}")
-    pass
 
 class OpenAIRateLimitError(Exception):
-    pass
+    def __init__(self) -> None:
+        super().__init__("Hit OpenAI Realtime API rate limit")
+
+class OpenAITimeoutError(Exception):
+    def __init__(self, timeout: float) -> None:
+        super().__init__(f"OpenAI websocket timed out because it did not receive a message in {timeout} seconds")
 
 
 INSTRUCTIONS = """
@@ -79,7 +85,7 @@ class OpenAIWebsocketClient:
         message = json.loads(self.ws.recv())
         self.session_id = message["session"]["id"]
         if message["type"] != "session.created":
-            raise SessionNotCreatedError("Session was not created")
+            raise SessionNotCreatedError()
 
     def _configure_session(self) -> None:
         self.ws.send(json.dumps({
@@ -101,11 +107,12 @@ class OpenAIWebsocketClient:
 
         message = json.loads(self.ws.recv())
         if message["type"] != "session.updated":
-            raise SessionNotUpdatedError("Session was not updated")
+            raise SessionNotUpdatedError()
 
 
 
     def send_audio(self, audio_chunk: bytes) -> None:
+        # Audio needs to be encoded in Base64 before being sent to the OpenAI Realtime API
         audio_b64 = base64.b64encode(audio_chunk).decode()
 
         self.ws.send(json.dumps({
@@ -113,13 +120,26 @@ class OpenAIWebsocketClient:
             "audio": audio_b64
         }))
 
-    def receive_text_response(self) -> str:
-        message = json.loads(self.ws.recv())
+    def receive_text_response(self, timeout:float=0.3) -> str:
+        try:
+            # Tries to receive the next message (in a blocking manner) from the OpenAI websocket
+            # If the message doesn't arrive in 300ms, then it raises a TimeoutError
+            message = json.loads(self.ws.recv(timeout=timeout))
+        except TimeoutError:
+            return OpenAITimeoutError(timeout=timeout)
+        
+        # Print message just to see what we're receiving
         print(message)
+
+        # Checks to see any general errors
         if message["type"] == "error":
             return OpenAIWebsocketError(error_code=message["error"]["code"], error_message=["error"]["message"])
+        
+        # Checks to see whether OpenAI is specifically rate limiting our responses
         if message["type"] == "response.done" and message["response"]["status_details"]["error"]["code"] == "rate_limit_exceeded":
-            return OpenAIRateLimitError("Hit OpenAI Realtime API rate limit")
+            return OpenAIRateLimitError()
+        
+        # Checks to see if an actual text response was sent, and returns the text
         if message["type"] == "response.text.done":
             return message["text"]
 


### PR DESCRIPTION
Context:
In `receive_text_response()`, we receive the next incoming message from the OpenAI Realtime API using the `self.ws.recv()` function. Since it is blocking, it waits until it receives a message from the API. This becomes a problem because the error messages from the API are also messages. This means that if a message is never received, we also never receive the error message either. 

What I added:
✅ I added a timeout to `self.ws.recv()` so that it times out in `300ms`. In other words, if it doesn't receive the next message within `300ms` it will raise a `TimeoutError`