### PR TITLE
feat: Offset the center of the grid by the radius of the robot and extended max radius of grid

### DIFF
--- a/packages/passive_sound_localization/passive_sound_localization/localization.py
+++ b/packages/passive_sound_localization/passive_sound_localization/localization.py
@@ -180,11 +180,11 @@ class SoundLocalizer:
         return cross_spectrum
     
     def _generate_circular_grid(
-        self, radius:float=1.0, num_points_radial:int=50, num_points_angular:int=360
+        self, offset:float=0.45, radius:float=1.0, num_points_radial:int=50, num_points_angular:int=360
     )-> np.ndarray[np.float32]:
         """Generate a grid of points on a circular plane, optimized for speed."""
         # Create radial distances from 0 to the specified radius
-        r = np.linspace(0, radius, num_points_radial, dtype=np.float32)
+        r = np.linspace(offset, radius + offset, num_points_radial, dtype=np.float32)
 
         # Create angular values from 0 to 2*pi
         theta = np.linspace(0, 2 * np.pi, num_points_angular, dtype=np.float32)


### PR DESCRIPTION
**Context:**
Currently I've been generating the circular grid naïvely starting at the origin:
<img width="775" alt="Naïve circular generation at origin" src="https://github.com/user-attachments/assets/959e329d-e933-4c91-ab00-9d19bfe5f3d0">

This becomes a problem because the center of the robot is at the origin. Since the robot has a diameter of roughly `0.45m`, then there's a lot of unnecessary grid points that are being generating inside the robot:
<img width="775" alt="Demonstration of unnecessary grid points being generated inside robot" src="https://github.com/user-attachments/assets/2510643c-dfe8-418c-b063-9e28bfb11730">

**What I did:**
I offset the generation of the circular grid so that it starts off the circumference of the robot. In addition, I offset the maximum radius of the grid by the radius of the robot. As a result, there's no unnecessary grid points being generated inside the robot and the grid now has more range.
<img width="776" alt="New circular grid generation offset by robot size" src="https://github.com/user-attachments/assets/f6e40e11-ad78-4f54-9550-1578f8b2f789">
