### PR TITLE
feat: Check Device Indices Utility Script

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,11 @@ This project identifies microphones by their device index to configure the audio
 
 ![Lab Laptop Input and Output Sound Settings](docs/screenshot_sound_input.png)
 
+Optionally, you can run the `check_device_indices` script to check what the current device indices are for the machine. To run `check_device_indices`, following command in a bash terminal:
+```bash
+poetry run python packages/passive_sound_localization/passive_sound_localization/check_device_indices.py
+```
+
 
 ## Microphone Volume Settings
 To ensure optimal performance and accurate sound localization, set each microphone’s volume to maximum in the system’s audio settings. This helps the microphones pick up voices clearly, even at a distance, improving the project's ability to detect and respond to people speaking. Low microphone volume can lead to inaccurate sound localization or missed voice detections. Check each microphone in **Settings > Sound > Input > Volume** to confirm the input volume is set to the highest level before starting the project.

--- a/packages/passive_sound_localization/passive_sound_localization/check_device_indices.py
+++ b/packages/passive_sound_localization/passive_sound_localization/check_device_indices.py
@@ -1,0 +1,21 @@
+import pyaudio
+
+def check_device_indices() -> None:
+    """
+    Lists and prints information about all audio input/output devices available on the system.
+
+    This function uses the PyAudio library to query and display detailed information about 
+    each audio device connected to the system. The information includes device name, index, 
+    supported input/output channels, sample rates, and other device-specific details.
+
+    Returns:
+        None
+    """
+    pyaudio_instance = pyaudio.PyAudio()
+    for mic_index in range(pyaudio_instance.get_device_count()):
+        device_info = pyaudio_instance.get_device_info_by_index(mic_index)
+        print(f"Device info: {device_info}")
+
+
+if __name__ == "__main__":
+    check_device_indices()

--- a/packages/passive_sound_localization/passive_sound_localization/realtime_audio_streamer.py
+++ b/packages/passive_sound_localization/passive_sound_localization/realtime_audio_streamer.py
@@ -21,10 +21,6 @@ class RealtimeAudioStreamer:
         self.streams = []
         self.audio_queues = [queue.Queue() for _ in self.mic_indices]
 
-        for mic_index in range(self.pyaudio_instance.get_device_count()):
-            device_info = self.pyaudio_instance.get_device_info_by_index(mic_index)
-            logger.info(f"Device info: {device_info}")
-
         logger.info(f"Mic indices: {self.mic_indices}")
         for mic_index in self.mic_indices:
             logger.debug(f"Opening stream for mic index: {mic_index}")


### PR DESCRIPTION
**Context:**
In order to get the microphones, we index into the list of available audio devices using the device index of each microphone. The device indices shift when ran on different machines, or if another audio device is added to the machine. As a result, many times we have to print out the device indices to debug.

**What I did:**
✅ Added a `check_device_indices.py` script that prints out the current device indices of the machine