### PR TITLE
feat: Only prints out input devices named "USB" in`check_device_indices`

### DIFF
--- a/packages/passive_sound_localization/passive_sound_localization/check_device_indices.py
+++ b/packages/passive_sound_localization/passive_sound_localization/check_device_indices.py
@@ -14,7 +14,8 @@ def check_device_indices() -> None:
     pyaudio_instance = pyaudio.PyAudio()
     for mic_index in range(pyaudio_instance.get_device_count()):
         device_info = pyaudio_instance.get_device_info_by_index(mic_index)
-        print(f"Device info: {device_info}")
+        if device_info['maxInputChannels'] > 0 and "USB" in device_info['name']:
+            print(f"Device info: {device_info}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Makes the script a little bit more convenient as then we don't need to filter through other devices in the list or devices that only have outputs.